### PR TITLE
Accept command line parameters --increment and --beta-increment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,11 +30,12 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     'increase-version': {
-      bower: {
-        options: {
-        },
+      options: {
+        defaultIncrement: 'patch'
+      },
+      package: {
         files: {
-          src: [ 'bower.json', '.bower.json' ]
+          src: [ 'package.json' ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
     "name": "grunt-increase-version",
     "description": "Increases package and bower version",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "homepage": "https://github.com/jstools/grunt-increase-version",
     "author": {
         "name": "Jesús Germade",
         "email": "jesus@germade.es",
         "url": "http://jesus.germade.es/"
+    },
+    "contributors": {
+        "name": "Ángel Brasero",
+        "url": "http://makmonty.com"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-increase-version",
     "description": "Increases package and bower version",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "homepage": "https://github.com/jstools/grunt-increase-version",
     "author": {
         "name": "Jesús Germade",

--- a/tasks/increase-version.js
+++ b/tasks/increase-version.js
@@ -10,6 +10,54 @@
 
 module.exports = function(grunt) {
 
+  grunt.getNextVersion = function(current, options) {
+    var validIncrements = ['major', 'minor', 'patch'];
+    var increment = grunt.option('increment') || options.defaultIncrement;
+    var betaIncrement = !!grunt.option('beta-increment');
+
+    if(!increment && !betaIncrement ||
+        (increment && validIncrements.indexOf(increment) == -1)) {
+      return false;
+    }
+
+    var currentSplit = current.split('-');
+
+    var versionSplit = currentSplit[0].split('.');
+    var betaSplit = null;
+
+    switch(increment) {
+      case 'major':
+        versionSplit[0] = parseInt(versionSplit[0]) + 1;
+        versionSplit[1] = 0;
+        versionSplit[2] = 0;
+        break;
+
+      case 'minor':
+        versionSplit[1] = parseInt(versionSplit[1]) + 1;
+        versionSplit[2] = 0;
+        break;
+
+      case 'patch':
+        versionSplit[2] = parseInt(versionSplit[2]) + 1;
+        break;
+    }
+
+    if(betaIncrement){
+      betaSplit = currentSplit[1] ? currentSplit[1].split('.') : null;
+      if( !betaSplit ){
+        betaSplit = ['beta', '0'];
+      }
+      betaSplit[1] = parseInt(betaSplit[1]) + 1;
+    }
+
+    var result = [versionSplit.join('.')];
+    if(betaSplit){
+      result.push(betaSplit.join('.'));
+    }
+
+    return result.join('-');
+  };
+
   grunt.registerMultiTask('increase-version', 'Increases package ( and specified files ) version', function() {
 
     var options = this.options({
@@ -17,11 +65,12 @@ module.exports = function(grunt) {
       separator: ', '
     });
 
-    var pkg = grunt.file.readJSON('package.json');
+    var pkg = grunt.file.readJSON(this.files[0].src);
+    var version = grunt.getNextVersion(pkg.version, options);
 
-    var version = pkg.version.split('.');
-    version[2]++;
-    version = version.join('.');
+    if(!version) {
+      return false;
+    }
 
     function writeVersion ( filepath ) {
       if( !grunt.file.exists(filepath) ) {
@@ -33,19 +82,17 @@ module.exports = function(grunt) {
       }
     }
 
-    writeVersion('package.json');
-
     this.files.forEach(function(f) {
 
       // Concat specified files.
       var src = f.orig.src.forEach(function(filepath) {
-
         writeVersion(filepath);
-
       });
 
       src += options.punctuation;
     });
+
+    return true;
   });
 
 };

--- a/tasks/increase-version.js
+++ b/tasks/increase-version.js
@@ -11,12 +11,13 @@
 module.exports = function(grunt) {
 
   grunt.getNextVersion = function(current, options) {
+    options = options || {};
     var validIncrements = ['major', 'minor', 'patch'];
     var increment = grunt.option('increment') || options.defaultIncrement;
     var betaIncrement = !!grunt.option('beta-increment');
 
     if(!increment && !betaIncrement ||
-        (increment && validIncrements.indexOf(increment) == -1)) {
+        (increment && validIncrements.indexOf(increment) === -1)) {
       return false;
     }
 


### PR DESCRIPTION
When running a increase-version task, I needed a way to specify in the command line which number of the version to increase, or to specify beta version.
I added two command line parameters for such requirement: --increment and --beta-increment
- --increment accepts three values: major, minor and patch
- --beta-increment adds -beta.X to the version. Starting with 1, if subsequent --beta-increment calls are made, it'll increase the X.

Also, a new option can be set: defaultIncrement. If set, it'll set the increment value if omited from the command line. If there's no defaultIncrement and no --increment parameter, the task will fail.
